### PR TITLE
requirements.txt: bump js2py version to 0.74 to fix python3.11 errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 beautifulsoup4==4.9.3
-Js2Py==0.71
+Js2Py==0.74
 requests==2.25.1


### PR DESCRIPTION
Fixes matricula-online-scraper  for python 3.11.

Fixes: #7